### PR TITLE
chore: add concurrency rules for integration tests

### DIFF
--- a/.github/workflows/sre-integration-smoke-tests.yaml
+++ b/.github/workflows/sre-integration-smoke-tests.yaml
@@ -13,6 +13,10 @@ on:
       - sre/roles/tools/**
       - sre/tools/kubernetes-topology-monitor/charts/kubernetes-topology-monitor/**
 
+concurrency:
+  group: ci-integration-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   chaos-mesh:
     name: Chaos Mesh Smoke Tests


### PR DESCRIPTION
This PR adds concurrency rules for the integration tests, namely that they be cancelled if there is a new push to a branch.