### PR TITLE
docs: update contribution instructions

### DIFF
--- a/sre/DEVELOPER_GUIDE.md
+++ b/sre/DEVELOPER_GUIDE.md
@@ -97,3 +97,52 @@ Remove all deployed components:
 make undeploy_applications
 make undeploy_tools
 ```
+
+# Contributing
+
+**Before writing a pull request, please ensure that you have read the [CONTRIBUTING.md](../CONTRIBUTING.md).**
+
+There are several ways to contribute to ITBench.
+
+## Add a new tool
+
+**Note:** It is recommended that a tool installed to a Kubernetes cluster use Helm as the deployment mechanism. This helps to simplify the deployment process and keeps the general uniformity of ITBench's deployment.
+
+1. Create tasks files in the tools role which handle the installation and uninstallation of the tool. These files should be titled `install_<tool name>` and `uninstall_<tool name>` respectively.
+  - The uninstallation process should remove all traces of the tool, including any CustomResourceDefinition (CRD) objects deployed to the cluster.
+2. Import the installation and uninstallation tasks, along with the conditions for their deployment, in the [`install.yaml`](./roles/tools/tasks/install.yaml) and the [`uninstall.yaml`](./roles/tools/tasks/uninstall.yaml).
+3. Expand the [tools argument spec](./roles/tools/meta/argument_specs.yaml) and add the tool to the [tools group variables](./group_vars/environment/tools.yaml.example). Also, update the [incident load task](./roles/incidents/tasks/load.yaml).
+4. Create a PR titled: `feat: new tool [<tool name>]`
+
+## Add a new application
+
+**Note:** It is recommended that an application installed to a Kubernetes cluster use Helm as the deployment mechanism. This helps to simplify the deployment process and keeps the general uniformity of ITBench's deployment.
+
+**Note:** It is recommended that an application uses OpenTelemetry in order to forward telemetry data to the observability tools. However, other softwares can also be used for this task.
+
+1. Create tasks files in the tools role which handle the installation and uninstallation of the tool. These files should be titled `install_<application name>` and `uninstall_<application name>` respectively.
+  - The uninstallation process should remove all traces of the application, including any CustomResourceDefinition (CRD) objects deployed to the cluster.
+2. Import the installation and uninstallation tasks, along with the conditions for their deployment, in the [`install.yaml`](./roles/applications/tasks/install.yaml) and the [`uninstall.yaml`](./roles/applications/tasks/uninstall.yaml).
+3. Expand the [applications argument spec](./roles/applications/meta/argument_specs.yaml) and add the tool to the [applications group variables](./group_vars/environment/applications.yaml.example). Also, update the [incident load task](./roles/incidents/tasks/load.yaml).
+4. Create a PR titled: `feat: new application [<application name>]`
+
+## Add a new fault injection (and removal)
+
+**Note:** When creating tasks, please use the given Ansible modules whenever possible. This reduces the overhead in reviewing the fault and keeps the uniformity of the ITBench codebase. For example, when making a task that creates a Kubernetes object, use the `kubernetes.core.k8s` collection instead of using `ansible.builtin.command` and invoking the kubectl CLI. The collections used in this project can be found [here](./requirements.yaml) and documentation for them can be found [here](https://docs.ansible.com/ansible/latest/collections/index.html).
+
+1. Create task files in the faults role which handle the injection and removal of the fault. These files should be title `inject_<fault type>_<fault name>` and `remove_<fault type>_<fault name>`.
+  - The fault type is acts as a grouping mechanism. For instance, `otel_demo` faults only work on the OpenTelementry Demo application and `valkey` faults only work on Valkey workloads. `custom` is the fault type given to generic faults which can be injected into any workload and will be the fault type used for new faults more often than not.
+  - The removal mechanism needs only to delete any new objects that were added to the environment as a result of the fault injection (ex: [Custom Fault: Misconfigured Resource Quota](./roles/faults/tasks/remove_custom_misconfigured_resource_quota.yaml)). Removal of the fault does not guarentee that the application will return to a stable state (ex: [Custom Fault: Misconfigured Service Port](./roles/faults/tasks/remove_custom_misconfigured_service_port.yaml))
+2. Import the injection to the appropriate file (ie, [inject_custom](./roles/faults/tasks/inject_custom.yaml) for custom faults) and removal tasks for the respective removal tasks.
+3. Expand the [faults argument spec](./roles/faults/meta/argument_specs.yaml)
+4. Create a new [incident spec](./roles/incidents/files/specs/) and [ground truth file](./roles/incidents/files/ground_truths/) to act as a sample to show how to use the new fault
+  - This file is titled `incident_<unique int id>`
+5. Create a PR titled: `feat: new fault [<fault name>]`
+
+## Add a new incident
+
+**Note:** The structure of the incident spec file is defined [here](./roles/incidents/meta/argument_specs.yaml) and the structure of the fault spec is defined [here](./roles/faults/meta/argument_specs.yaml).
+
+1. Create a new [incident spec](./roles/incidents/files/specs/) and [ground truth file](./roles/incidents/files/ground_truths/) to act as a sample to show how to use the new fault
+  - This file is titled `incident_<unique int id>`
+2. Create a PR titled: `feat: new incident [<incident id>]`

--- a/sre/docs/applications.md
+++ b/sre/docs/applications.md
@@ -1,18 +1,6 @@
-# ITBench: SRE Applications
+# ITBench: Applications
 
 ## [OpenTelemetry's Astronomy Shop](https://github.com/open-telemetry/opentelemetry-demo)
 
 OpenTelemetry's Astronomy Shop is a microservice-based distributed system intended to illustrate the implementation of OpenTelemetry in a near real-world environment.
 An architectural diagram for the same can be found [here](https://opentelemetry.io/docs/demo/architecture/).
-
-### Installing OpenTelemetry's Astronomy Shop
-To install the application run:
-```bash
-make deploy_applications
-```
-
-### Uninstalling OpenTelemetry's Astronomy Shop
-To uninstall the application run:
-```bash
-make undeploy_applications
-```

--- a/sre/docs/tools.md
+++ b/sre/docs/tools.md
@@ -1,30 +1,81 @@
-# ITBench: Observability Tools
+# ITBench: Tools
 
 ## Overview
-Depending on the scenario domain (SRE or FinOps), the following tools are deployed:
-| Tool | Scenario Domain(s) | Repository |
+
+ITBench uses a variety of open-source softwares to inject faults into the environment and collect telemetry data from the applications.
+
+### Observability Tools
+
+An **observability tool** is a technology which collects telemetry data to provide insights on the health and status of application at run time. Generally, this data can fall under one of the following categories:
+
+1. Logs
+2. Metrics
+3. Traces
+
+ITBench makes use of the following tools to process observability data:
+
+| Tool | Repository | Function | Observability Data Type(s) |
+| --- | --- | --- | --- |
+| Altinity Clickhouse | https://github.com/Altinity/ClickHouse | Storage | Logs, Traces |
+| Altinity Clickhouse Operator | https://github.com/Altinity/clickhouse-operator | Storage | Logs, Traces |
+| Jaeger | https://github.com/jaegertracing/jaeger | Collector | Traces |
+| OpenSearch | https://github.com/opensearch-project/OpenSearch | Storage | Logs, Traces |
+| OpenTelemetry Collector | https://github.com/open-telemetry/opentelemetry-collector | Collector | Logs, Traces, Metrics |
+| OpenTelemetry Operator | https://github.com/open-telemetry/opentelemetry-operator | Collector | Logs, Traces, Metrics |
+| Prometheus | https://github.com/prometheus/prometheus | Collector | Metrics |
+| Prometheus Operator | https://github.com/prometheus-operator/prometheus-operator | Collector | Metrics |
+
+Unless explicitly deactivated, these tools are always deployed in the environment. For more information about each tool, please review the documentation provided in the respective tool's GitHub repository.
+
+**Note:** When deploying Jaeger, OpenSearch is deployed as a storage unit for the traces received by Jaeger, regardless of whether OpenSearch is part of the active install list during an incident.
+
+### Chaos Engineering Tools
+
+A **chaos engineering tool** is a technology which injects faults into an environment. This allows developers to test various cases in the application stack for a variety of conditions.
+
+In ITBench, the following tool is used:
+
+| Tool | Repository |
+| --- | --- |
+| Chaos Mesh | https://github.com/chaos-mesh/chaos-mesh |
+
+In order to use a Chaos Mesh fault, Chaos Mesh should be specified as part of the tools required and a valid Chaos Mesh schedule needs to be provided. Examples of using a Chaos Mesh fault are provided by [Incident 26](../roles/incidents/files/specs/incident_26.yaml) and [Incident 27](../roles/incidents/files/specs/incident_27.yaml). Examples and guides for making a valid Chaos Mesh schedule spec can be found on their website or their GitHub repository.
+
+### FinOps Tools
+
+A **finops tool** is a techonology which provides financial insights on the operational costs of running an application.
+
+In ITBench, the following tool is used:
+
+| Tool | Repository |
+| --- | --- |
+| OpenCost | https://github.com/opencost/opencost |
+
+**Note:** When deploying OpenCost, Prometheus is deployed as a required dependency, regardless of whether Prometheus is part of the active install list during an incident.
+
+### Kubernetes Tools
+
+ITBench deploys additional Kubernetes tools to enable additional features in a Kubernetes cluster.
+
+| Tool | Repository | Function |
 | --- | --- | --- |
-| Altinity Clickhouse | FinOps, SRE | https://github.com/Altinity/ClickHouse |
-| Altinity Clickhouse Operator | FinOps, SRE | https://github.com/Altinity/clickhouse-operator |
-| Chaos Mesh | SRE | https://github.com/chaos-mesh/chaos-mesh |
-| Jaeger | FinOps, SRE | https://github.com/jaegertracing/jaeger |
-| Kubernetes Ingress | FinOps, SRE | https://github.com/kubernetes/ingress-nginx |
-| Kubernetes Metric Server | FinOps | https://github.com/kubernetes-sigs/metrics-server |
-| OpenCost | FinOps | https://github.com/opencost/opencost |
-| OpenSearch | FinOps, SRE | https://github.com/opensearch-project/OpenSearch |
-| OpenTelemetry Collector | FinOps, SRE | https://github.com/open-telemetry/opentelemetry-collector |
-| OpenTelemetry Operator | FinOps, SRE | https://github.com/open-telemetry/opentelemetry-operator |
-| Prometheus | FinOps, SRE | https://github.com/prometheus/prometheus |
-| Prometheus Operator | FinOps, SRE | https://github.com/prometheus-operator/prometheus-operator |
+| Kubernetes Metric Server | https://github.com/kubernetes-sigs/metrics-server | Autoscaling |
+| Kubernetes NGINX Controller | https://github.com/kubernetes/ingress-nginx | Networking |
 
-### Installing observability tools for SRE scenarios
-Run:
-```bash
-make deploy_tools
-```
+**Note:** Kubernetes NGINX Controller provides Ingress support which allows a user to externally access an observability tool's UI. This is useful for debugging, but explicitely needed. However, it is still always deployed as part of the tool stack unless deactivated.
 
-### Uninstalling observability tools for SRE scenarios
-Run:
-```bash
-make undeploy_tools
-```
+**Note:** Due to increasing load being a frequent need in FinOps incidents (to "raise" cost), the Kubernetes Metrics Server is always deployed as part of the tool stack for FinOps scenarios unless deactivated. To install it as part of an SRE scenario, it needs to be explicitely added to the incident spec.
+
+## Additional Notes
+
+### OpenShift
+
+OpenShift provides a variety of Observability and Kubernetes tools out of the box. When deploying on this platform, ITBench will use these provided softwares rather than deploy its own instance of them as it does in a Kubernetes cluster.
+
+The following tools are provided by OpenShift and are not installed by ITBench:
+
+1. Prometheus & Prometheus Operator
+2. OpenTelemetry Operator
+3. Kubernetes Metrics Server
+
+In addition, when deploying on OpenShift, the Kubernetes NGINX Controller is not installed. Instead, Routes are used to provided external networking access to the observability tools.


### PR DESCRIPTION
This PR updates the documentation to provide instructions on how developers and practitioners can contribute to ITBench for the SRE and FinOps domains.