### PR TITLE
feat: add agent role for telemetry access

### DIFF
--- a/sre/roles/agent/files/role.yaml
+++ b/sre/roles/agent/files/role.yaml
@@ -1,0 +1,68 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: agent-access
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+      - services
+      - configmaps
+      - secrets
+      - endpoints
+      - persistentvolumeclaims
+      - nodes
+      - namespaces
+      - events
+      - persistentvolumes
+      - pods/exec
+      - pods/attach
+      - pods/portforward
+      - pods/log
+      - resourcequotas
+    verbs:
+      - "*"
+  - apiGroups:
+      - apps
+    resources:
+      - deployments
+      - replicasets
+      - daemonsets
+      - statefulsets
+    verbs:
+      - "*"
+  - apiGroups:
+      - batch
+    resources:
+      - jobs
+      - cronjobs
+    verbs:
+      - "*"
+  - apiGroups:
+      - autoscaling
+    resources:
+      - horizontalpodautoscalers
+    verbs:
+      - "*"
+  - apiGroups:
+      - rbac.authorization.k8s.io
+    resources:
+      - roles
+      - rolebindings
+    verbs:
+      - "*"
+  - apiGroups:
+      - policy
+    resources:
+      - poddisruptionbudgets
+    verbs:
+      - "*"
+  - apiGroups:
+      - networking.k8s.io
+    resources:
+      - networkpolicies
+      - ingresses
+    verbs:
+      - "*"

--- a/sre/roles/agent/files/serviceaccount.yaml
+++ b/sre/roles/agent/files/serviceaccount.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: agent

--- a/sre/roles/agent/files/tokenrequest.yaml
+++ b/sre/roles/agent/files/tokenrequest.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: authentication.k8s.io/v1
+kind: TokenRequest
+metadata:
+  name: agent
+spec:
+  expirationSeconds: 64800 # 18h

--- a/sre/roles/agent/meta/argument_specs.yaml
+++ b/sre/roles/agent/meta/argument_specs.yaml
@@ -1,0 +1,60 @@
+---
+argument_specs:
+  add_telemetry_access:
+    short_description: Main entry point for applications role
+    description:
+      - This role is responsible for installing and uninstalling the applications that
+        faults will be injected to for benchmarking.
+    author:
+      - Gerard Vanloo
+    options:
+      agent_application:
+        required: true
+        type: dict
+        options:
+          namespace:
+            required: true
+            type: str
+      agent_cluster:
+        description:
+          - The Kubernetes or OpenShift cluster that the application(s) will be installed to
+            or uninstalled from.
+        required: true
+        type: dict
+        options:
+          kubeconfig:
+            description:
+              - The file path of the Kubernetes configuration file.
+              - Use '~' over '$HOME' to substitute for the root directory or provide
+                the absolute path.
+            required: true
+            type: str
+  remove_telemetry_access:
+    short_description: Main entry point for applications role
+    description:
+      - This role is responsible for installing and uninstalling the applications that
+        faults will be injected to for benchmarking.
+    author:
+      - Gerard Vanloo
+    options:
+      agent_application:
+        required: true
+        type: dict
+        options:
+          namespace:
+            required: true
+            type: str
+      agent_cluster:
+        description:
+          - The Kubernetes or OpenShift cluster that the application(s) will be installed to
+            or uninstalled from.
+        required: true
+        type: dict
+        options:
+          kubeconfig:
+            description:
+              - The file path of the Kubernetes configuration file.
+              - Use '~' over '$HOME' to substitute for the root directory or provide
+                the absolute path.
+            required: true
+            type: str

--- a/sre/roles/agent/tasks/add_telemetry_access.yaml
+++ b/sre/roles/agent/tasks/add_telemetry_access.yaml
@@ -1,0 +1,31 @@
+---
+- name: Create Service Account
+  kubernetes.core.k8s:
+    kubeconfig: "{{ agent_cluster.kubeconfig }}"
+    namespace: "{{ agent_application.namesapce }}"
+    src: files/serviceaccount.yaml
+    state: present
+
+- name: Create Role
+  kubernetes.core.k8s:
+    kubeconfig: "{{ agent_cluster.kubeconfig }}"
+    namespace: "{{ agent_application.namesapce }}"
+    src: files/role.yaml
+    state: present
+
+- name: Create RoleBinding
+  kubernetes.core.k8s:
+    kubeconfig: "{{ agent_cluster.kubeconfig }}"
+    namespace: "{{ agent_application.namesapce }}"
+    template: templates/rolebinding.j2
+    state: present
+  vars:
+    service_account_namespace: "{{ agent_application.namesapce }}"
+
+- name: Create TokenRequest
+  kubernetes.core.k8s:
+    kubeconfig: "{{ agent_cluster.kubeconfig }}"
+    namespace: "{{ agent_application.namesapce }}"
+    src: files/tokenrequest.yaml
+    state: present
+  register: agent_token_request

--- a/sre/roles/agent/tasks/generate_restricted_kubeconfig.yaml
+++ b/sre/roles/agent/tasks/generate_restricted_kubeconfig.yaml
@@ -1,0 +1,35 @@
+---
+- name: Load kubeconfig file
+  ansible.builtin.set_fact:
+    agent_kubeconfig: "{{ lookup('ansible.builtin.file', agent_cluster.kubeconfig) | from_yaml }}"
+
+- name: Find index of current context cluster
+  ansible.builtin.set_fact:
+    agent_cluster_index: "{{ lookup('ansible.utils.index_of', agent_kubeconfig.clusters, 'eq', cluster, 'name') }}"
+  vars:
+    cluster: "{{ agent_kubeconfig['current-context'] }}"
+
+- name: Generate contexts and users
+  ansible.builtin.set_fact:
+    agent_contexts: "{{ (agent_contexts | default([])) + [{'cluster': cluster, 'user': 'agent', 'namespace': kv.key}] }}"
+    agent_users: "{{ (agent_users | default([])) +[{'name': 'agent', 'user': {'token': kv.value}}] }}"
+  loop: "{{ agent_application_tokens | dict2items }}"
+  loop_control:
+    label: application/{{ kv.key }}
+    loop_var: kv
+  vars:
+    cluster: "{{ agent_kubeconfig['current-context'] }}"
+  when:
+    - kv.value != ""
+
+- name: Create restricted kubeconfig file in temporary directory
+  ansible.builtin.copy:
+    content: "{{ lookup('ansible.builtin.template', 'templates/kubeconfig.j2') | from_yaml | to_nice_yaml(indent=2) }}"
+    dest: /tmp/restricted_config
+    mode: "0644"
+  vars:
+    certificate_authority_data: "{{ agent_kubeconfig.clusters[agent_cluster_index].cluster['certificate-authority-data'] }}"
+    cluster: "{{ agent_kubeconfig.clusters[agent_cluster_index].name }}"
+    contexts: "{{ agent_contexts }}"
+    server: "{{ agent_kubeconfig.clusters[agent_cluster_index].cluster.server }}"
+    users: "{{ agent_users }}"

--- a/sre/roles/agent/tasks/remove_telemetry_access.yaml
+++ b/sre/roles/agent/tasks/remove_telemetry_access.yaml
@@ -1,0 +1,26 @@
+---
+- name: Delete RoleBinding
+  kubernetes.core.k8s:
+    kubeconfig: "{{ agent_cluster.kubeconfig }}"
+    namespace: "{{ agent_application.namesapce }}"
+    template: templates/rolebinding.j2
+    state: absent
+    wait: true
+  vars:
+    service_account_namespace: "{{ agent_application.namesapce }}"
+
+- name: Delete Role
+  kubernetes.core.k8s:
+    kubeconfig: "{{ agent_cluster.kubeconfig }}"
+    namespace: "{{ agent_application.namesapce }}"
+    src: files/role.yaml
+    state: absent
+    wait: true
+
+- name: Delete Service Account
+  kubernetes.core.k8s:
+    kubeconfig: "{{ agent_cluster.kubeconfig }}"
+    namespace: "{{ agent_application.namesapce }}"
+    src: files/serviceaccount.yaml
+    state: absent
+    wait: true

--- a/sre/roles/agent/templates/kubeconfig.j2
+++ b/sre/roles/agent/templates/kubeconfig.j2
@@ -1,0 +1,12 @@
+---
+apiVersion: v1
+kind: Config
+preferences: {}
+clusters:
+  - cluster:
+      server: {{ server }}
+      certificate-authority-data: {{ certificate_authority_data }}
+    name: {{ cluster }}
+contexts:  {{ contexts }}
+current-context: {{ cluster }}
+users: {{ users }}

--- a/sre/roles/agent/templates/rolebinding.j2
+++ b/sre/roles/agent/templates/rolebinding.j2
@@ -1,0 +1,13 @@
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: agent-access
+subjects:
+  - kind: ServiceAccount
+    name: agent
+    namespace: "{{ service_account_namespace }}"
+roleRef:
+  kind: Role
+  name: agent-access
+  apiGroup: rbac.authorization.k8s.io

--- a/sre/roles/applications/tasks/install.yaml
+++ b/sre/roles/applications/tasks/install.yaml
@@ -21,14 +21,12 @@
     - applications_required.otel_demo is defined
     - applications_required.otel_demo.enabled
 
-# TODO: Enable these tasks during the refactor of the e2e
-
-# - name: Import Deployment Time tasks
-#   ansible.builtin.import_tasks:
-#     file: register_deployment_time.yaml
-
-# - name: Import Deployment Failure tasks
-#   ansible.builtin.import_tasks:
-#     file: register_deployment_failure.yaml
-#   when:
-#     - (sre_bench_runner | default(false))
+- name: Import agents role for restricted kubeconfig generation
+  ansible.builtin.import_role:
+    name: agent
+    tasks_from: generate_restricted_kubeconfig
+  vars:
+    agent_application_tokens:
+      "{{ applications_helm_releases.otel_demo.namespace }}": "{{ applications_otel_demo_token | default('') }}"
+    agent_cluster:
+      kubeconfig: "{{ cluster.kubeconfig }}"

--- a/sre/roles/applications/tasks/install_otel_demo.yaml
+++ b/sre/roles/applications/tasks/install_otel_demo.yaml
@@ -399,3 +399,7 @@
       namespace: "{{ helm_release.namespace }}"
     agent_cluster:
       kubeconfig: "{{ cluster.kubeconfig }}"
+
+- name: Set token variable for telemetry access
+  ansible.builtin.set_fact:
+    applications_otel_demo_token: "{{ agent_token_request.result.status.token }}"

--- a/sre/roles/applications/tasks/install_otel_demo.yaml
+++ b/sre/roles/applications/tasks/install_otel_demo.yaml
@@ -389,3 +389,13 @@
     label: horizontalpodautoscaler/{{ item | regex_replace('_', '-') }}
   when:
     - configuration[item].autoscaling | default(false)
+
+- name: Import agents role to add agent RBAC
+  ansible.builtin.import_role:
+    name: agent
+    tasks_from: add_telemetry_access.yaml
+  vars:
+    agent_application:
+      namespace: "{{ helm_release.namespace }}"
+    agent_cluster:
+      kubeconfig: "{{ cluster.kubeconfig }}"

--- a/sre/roles/applications/tasks/uninstall_otel_demo.yaml
+++ b/sre/roles/applications/tasks/uninstall_otel_demo.yaml
@@ -1,4 +1,14 @@
 ---
+- name: Import agents role to remove agent RBAC
+  ansible.builtin.import_role:
+    name: agent
+    tasks_from: remove_telemetry_access.yaml
+  vars:
+    agent_application:
+      namespace: "{{ helm_release.namespace }}"
+    agent_cluster:
+      kubeconfig: "{{ cluster.kubeconfig }}"
+
 - name: Remove Horizontal Pod Autoscalers
   kubernetes.core.k8s:
     api_version: autoscaling/v2


### PR DESCRIPTION
This PR adds functionality to create a kubeconfig file which allows an agent to access the application namespace.