### PR TITLE
feat: add export command for AWX clusters kubeconfigs

### DIFF
--- a/sre/dev/remote_cluster/Makefile
+++ b/sre/dev/remote_cluster/Makefile
@@ -41,6 +41,10 @@ endif
 create_awx_stack: ## Creates an AWX stack created by kops
 	ansible-playbook -i inventory.yaml playbooks/manage_awx_stack.yaml --tags "create"
 
+.PHONY: export_awx_kubeconfigs
+export_awx_kubeconfigs: ## Exports the kubeconfigs of all clusters used in an AWX stack
+	ansible-playbook -i inventory.yaml playbooks/manage_awx_stack.yaml --tags "export"
+
 .PHONY: destroy_awx_stack
 destroy_awx_stack: ## Destroy an AWX stack created by kops
 	ansible-playbook -i inventory.yaml playbooks/manage_awx_stack.yaml --tags "delete"

--- a/sre/dev/remote_cluster/roles/awx/tasks/create_async.yaml
+++ b/sre/dev/remote_cluster/roles/awx/tasks/create_async.yaml
@@ -23,7 +23,7 @@
     map_public: true
     state: present
     tags:
-      Name: "{{ awx_stack.name_prefix }}-public-subnet-{{ item }}"
+      Name: "{{ awx_stack.name_prefix }}-public-subnet-{{ item | string }}"
       Environment: k8s
       ManagedBy: ansible
   loop: "{{ range(1, (awx_cluster_names | length) + 1) | list }}"

--- a/sre/dev/remote_cluster/roles/awx/tasks/export.yaml
+++ b/sre/dev/remote_cluster/roles/awx/tasks/export.yaml
@@ -1,0 +1,43 @@
+---
+- name: Export the kubeconfig
+  ansible.builtin.command:
+    argv:
+      - kops
+      - export
+      - --name
+      - "{{ item }}"
+      - kubecfg
+      - --admin
+      - --state
+      - "{{ awx_kops_state_store }}"
+      - --kubeconfig
+      - /tmp/{{ item }}.yaml
+  register: awx_export_output
+  changed_when: awx_export_output.rc == 0
+  loop: "{{ awx_runner_cluster_names + [awx_head_cluster_name] }}"
+
+- name: Update stack group variables file
+  ansible.builtin.copy:
+    content: "{{ stack_definition | to_nice_yaml(indent=2) }}"
+    dest: "../../../group_vars/runner/stack.yaml"
+    mode: "0644"
+  vars:
+    stack_definition:
+      stack:
+        awx:
+          kubeconfig: /tmp/{{ awx_head_cluster_name }}.yaml
+        runners:
+          kubeconfigs: |
+            {{
+              [] |
+              zip_longest(awx_runner_cluster_names, fillvalue="/tmp") |
+              map('join', '/') |
+              zip_longest([], fillvalue="yaml") |
+              map('join', '.')
+            }}
+
+- name: Display the export environment variable command for the head cluster
+  ansible.builtin.debug:
+    msg:
+      - "Run the following command to execute kubectl commands:"
+      - export KUBECONFIG=/tmp/{{ awx_head_cluster_name }}.yaml

--- a/sre/dev/remote_cluster/roles/awx/tasks/main.yaml
+++ b/sre/dev/remote_cluster/roles/awx/tasks/main.yaml
@@ -55,6 +55,12 @@
   tags:
     - create
 
+- name: Import export tasks
+  ansible.builtin.import_tasks:
+    file: export.yaml
+  tags:
+    - export
+
 - name: Import asynchronous AWX stack deletion tasks
   ansible.builtin.import_tasks:
     file: delete_async.yaml


### PR DESCRIPTION
This PR adds new functionality to export all the kubeconfigs used for the AWX stack. This is available through the new `make export_awx_kubeconfigs` command. This command also updates the `stack.yaml` group variable file with the kubeconfigs to simplify set up.