### PR TITLE
chore: stop setting environment in system role

### DIFF
--- a/sre/roles/system/tasks/check_kubectl_version.yaml
+++ b/sre/roles/system/tasks/check_kubectl_version.yaml
@@ -14,9 +14,12 @@
 
 - name: Get kubectl client version
   ansible.builtin.command:
-    cmd: "{{ system_kubectl_path.stdout }} version -o json"
-  environment:
-    KUBECONFIG: "{{ system_cluster.kubeconfig | ansible.builtin.expanduser }}"
+    argv:
+      - "{{ system_kubectl_path.stdout }}"
+      - version
+      - -o
+      - json
+      - --kubeconfig='{{ system_cluster.kubeconfig | ansible.builtin.expanduser }}'
   register: system_raw_kubectl_version
   changed_when: false
 


### PR DESCRIPTION
When updating to the most recent Ansible, the setting of the `environment` is flagged as deprecated. Thus, this PR removes the setting of the `environment` where possible.