### PR TITLE
bump: update otel-demo and observability tools to latest versions

### DIFF
--- a/sre/roles/applications/defaults/main/configurations.yaml
+++ b/sre/roles/applications/defaults/main/configurations.yaml
@@ -41,6 +41,9 @@ applications_configurations:
     payment:
       autoscaling: false
       replicas: 1
+    postgres:
+      autoscaling: false
+      replicas: 1
     product_catalog:
       autoscaling: false
       replicas: 1

--- a/sre/roles/applications/tasks/install_otel_demo.yaml
+++ b/sre/roles/applications/tasks/install_otel_demo.yaml
@@ -62,16 +62,13 @@
   kubernetes.core.helm:
     chart_ref: opentelemetry-demo
     chart_repo_url: https://open-telemetry.github.io/opentelemetry-helm-charts
-    chart_version: 0.37.8
+    chart_version: 0.38.0
     kubeconfig: "{{ applications_cluster.kubeconfig }}"
     release_name: "{{ helm_releases.otel_demo.name }}"
     release_namespace: "{{ helm_releases.otel_demo.namespace }}"
     release_state: present
     timeout: 10m0s
     values:
-      default:
-        image:
-          tag: nightly-17419153244 # New version with compatible image provider not released yet
       components:
         accounting:
           podAnnotations:
@@ -110,9 +107,6 @@
               cpu: 30m
               memory: 110Mi
         checkout:
-          envOverrides:
-            - name: SHIPPING_ADDR
-              value: http://shipping:8080
           podAnnotations:
             openshift.io/required-scc: restricted-v2
           replicas: "{{ configuration.checkout.replicas }}"
@@ -167,9 +161,6 @@
               cpu: 50m
               memory: 400Mi
         frontend:
-          envOverrides:
-            - name: SHIPPING_ADDR
-              value: http://shipping:8080
           podAnnotations:
             openshift.io/required-scc: restricted-v2
           replicas: "{{ configuration.frontend.replicas }}"
@@ -206,8 +197,6 @@
               cpu: 5m
               memory: 15Mi
         kafka:
-          imageOverride:
-            tag: 2.0.2-kafka
           podAnnotations:
             openshift.io/required-scc: restricted-v2
           replicas: "{{ configuration.kafka.replicas }}"
@@ -246,6 +235,17 @@
             limits:
               cpu: 20m
               memory: 160Mi
+        postgresql:
+          podAnnotations:
+            openshift.io/required-scc: restricted-v2
+          replicas: "{{ configuration.postgres.replicas }}"
+          resources:
+            requests:
+              cpu: 25m
+              memory: 50Mi
+            limits:
+              cpu: 50m
+              memory: 100Mi
         product-catalog:
           podAnnotations:
             openshift.io/required-scc: restricted-v2

--- a/sre/roles/incidents/files/specs/incident_37.yaml
+++ b/sre/roles/incidents/files/specs/incident_37.yaml
@@ -36,6 +36,8 @@ spec:
             users: 30
           payment:
             autoscaling: true
+          postgres:
+            autoscaling: true
           product_catalog:
             autoscaling: true
           quote:

--- a/sre/roles/incidents/files/specs/incident_38.yaml
+++ b/sre/roles/incidents/files/specs/incident_38.yaml
@@ -36,6 +36,8 @@ spec:
             users: 30
           payment:
             autoscaling: true
+          postgres:
+            autoscaling: true
           product_catalog:
             autoscaling: true
           quote:

--- a/sre/roles/tools/tasks/install_clickhouse.yaml
+++ b/sre/roles/tools/tasks/install_clickhouse.yaml
@@ -15,7 +15,7 @@
   kubernetes.core.helm:
     chart_ref: altinity-clickhouse-operator
     chart_repo_url: https://docs.altinity.com/clickhouse-operator/
-    chart_version: 0.25.3
+    chart_version: 0.25.4
     kubeconfig: "{{ tools_cluster.kubeconfig }}"
     release_name: "{{ helm_release.name }}"
     release_namespace: "{{ helm_release.namespace }}"

--- a/sre/roles/tools/tasks/install_ingress.yaml
+++ b/sre/roles/tools/tasks/install_ingress.yaml
@@ -17,7 +17,7 @@
   kubernetes.core.helm:
     chart_ref: ingress-nginx
     chart_repo_url: https://kubernetes.github.io/ingress-nginx
-    chart_version: 4.13.2
+    chart_version: 4.13.3
     kubeconfig: "{{ tools_cluster.kubeconfig }}"
     release_name: "{{ helm_release.name }}"
     release_namespace: "{{ helm_release.namespace }}"

--- a/sre/roles/tools/tasks/install_opencost.yaml
+++ b/sre/roles/tools/tasks/install_opencost.yaml
@@ -23,7 +23,7 @@
   kubernetes.core.helm:
     chart_ref: opencost
     chart_repo_url: https://opencost.github.io/opencost-helm-chart
-    chart_version: 2.2.7
+    chart_version: 2.2.9
     kubeconfig: "{{ tools_cluster.kubeconfig }}"
     release_name: "{{ helm_release.name }}"
     release_namespace: "{{ helm_release.namespace }}"

--- a/sre/roles/tools/tasks/install_opentelemetry.yaml
+++ b/sre/roles/tools/tasks/install_opentelemetry.yaml
@@ -149,7 +149,7 @@
   kubernetes.core.helm:
     chart_ref: opentelemetry-operator
     chart_repo_url: https://open-telemetry.github.io/opentelemetry-helm-charts
-    chart_version: 0.95.1
+    chart_version: 0.97.0
     kubeconfig: "{{ tools_cluster.kubeconfig }}"
     release_name: "{{ helm_releases.operator.name }}"
     release_namespace: "{{ helm_releases.operator.namespace }}"

--- a/sre/roles/tools/tasks/install_prometheus.yaml
+++ b/sre/roles/tools/tasks/install_prometheus.yaml
@@ -17,7 +17,7 @@
   kubernetes.core.helm:
     chart_ref: kube-prometheus-stack
     chart_repo_url: https://prometheus-community.github.io/helm-charts
-    chart_version: 77.8.0
+    chart_version: 77.12.0
     kubeconfig: "{{ tools_cluster.kubeconfig }}"
     release_name: "{{ helm_release.name }}"
     release_namespace: "{{ helm_release.namespace }}"


### PR DESCRIPTION
This PR updates all software released by Helm charts to their latest release version.